### PR TITLE
Move grid_x, grid_y creation to GPU

### DIFF
--- a/utils/point_utils.py
+++ b/utils/point_utils.py
@@ -16,7 +16,7 @@ def depths_to_points(view, depthmap):
         [0., fy, H/2.],
         [0., 0., 1.0]]
     ).float().cuda()
-    grid_x, grid_y = torch.meshgrid(torch.arange(W), torch.arange(H), indexing='xy')
+    grid_x, grid_y = torch.meshgrid(torch.arange(W).cuda(), torch.arange(H).cuda(), indexing='xy')
     # TODO: reduce dynamic allocation for speed 
     points = torch.stack([grid_x, grid_y, torch.ones_like(grid_x)], dim=-1).reshape(-1, 3).float().cuda()
     rays_d = points @ intrins.inverse().T @ c2w[:3,:3].T


### PR DESCRIPTION
#3

training log:
python train.py -s ../../datasets/DTU_mask/scan105 -r 2
. . .
Training progress:  23%|▏| 6810/30000 [01:58<07:19, 52.80it/s, Loss=0.03527, distort=0.00033, normal=0.00000, Points=142 

top log:
│ GPU     PID      USER  GPU-MEM %SM  %CPU  %MEM      TIME  COMMAND                                                                    │
│   5 3385567 C     xxx  1724MiB        86  **99.8**   0.2      2:49  python train.py -s ../../datasets/DTU_mask/scan105 -r 2