### PR TITLE
reduce VRAM requirement

### DIFF
--- a/scene/cameras.py
+++ b/scene/cameras.py
@@ -36,7 +36,7 @@ class Camera(nn.Module):
             print(f"[Warning] Custom device {data_device} failed, fallback to default cuda device" )
             self.data_device = torch.device("cuda")
 
-        self.original_image = image.clamp(0.0, 1.0).to(self.data_device)
+        self.original_image = image.clamp(0.0, 1.0) # move to device at dataloader to reduce VRAM requirement
         self.image_width = self.original_image.shape[2]
         self.image_height = self.original_image.shape[1]
 
@@ -44,7 +44,7 @@ class Camera(nn.Module):
             # self.original_image *= gt_alpha_mask.to(self.data_device)
             self.gt_alpha_mask = gt_alpha_mask.to(self.data_device)
         else:
-            self.original_image *= torch.ones((1, self.image_height, self.image_width), device=self.data_device)
+            # self.original_image *= torch.ones((1, self.image_height, self.image_width), device=self.data_device) # do we need this?
             self.gt_alpha_mask = None
         
         self.zfar = 100.0

--- a/train.py
+++ b/train.py
@@ -185,7 +185,7 @@ def training_report(tb_writer, iteration, Ll1, loss, l1_loss, elapsed, testing_i
                 psnr_test = 0.0
                 for idx, viewpoint in enumerate(config['cameras']):
                     render_pkg = renderFunc(viewpoint, scene.gaussians, *renderArgs)
-                    image = torch.clamp(render_pkg["render"], 0.0, 1.0)
+                    image = torch.clamp(render_pkg["render"], 0.0, 1.0).to("cuda")
                     gt_image = torch.clamp(viewpoint.original_image.to("cuda"), 0.0, 1.0)
                     if tb_writer and (idx < 5):
                         from utils.general_utils import colormap


### PR DESCRIPTION
Hi,

I use a system with a single graphic card (VRAM 16GB) and high memory instead (because RAM expansion is always cheaper than VRAM expansion)
Therefore, I had to lower the volume of VRAM and load the images into the memory.

Simply not loading the original_image to the cuda in class Camera, I got what I expected.
There are no other problems, as in the training part, the loss function is already calculated with the following:

gt_image = torch.clamp(viewpoint.original_image.to("cuda"), 0.0, 1.0)
l1_test += l1_loss(image, gt_image).mean().double()

Please merge if you find this useful.
Thanks for your great work!
