### PR TITLE
Update mesh_utils.py

### DIFF
--- a/utils/mesh_utils.py
+++ b/utils/mesh_utils.py
@@ -116,8 +116,8 @@ class GaussianExtractor(object):
             # self.normals.append(normal.cpu())
             # self.depth_normals.append(depth_normal.cpu())
         
-        self.rgbmaps = torch.stack(self.rgbmaps, dim=0)
-        self.depthmaps = torch.stack(self.depthmaps, dim=0)
+        # self.rgbmaps = torch.stack(self.rgbmaps, dim=0)
+        # self.depthmaps = torch.stack(self.depthmaps, dim=0)
         # self.alphamaps = torch.stack(self.alphamaps, dim=0)
         # self.depth_normals = torch.stack(self.depth_normals, dim=0)
         self.estimate_bounding_sphere()


### PR DESCRIPTION
Just a simple fix. 

If image calibration is performed through COLMAP undistortion, the image size of the dataset may be different, so it cannot be created as a nested tensor with 'torch.stack'.  
Even with the List of tensors, there are no errors in the subsequent algorithms.