### PR TITLE
Question about loading masks from nerf_synthetic dataset

### DIFF
--- a/scene/dataset_readers.py
+++ b/scene/dataset_readers.py
@@ -207,7 +207,9 @@ def readCamerasFromTransforms(path, transformsfile, white_background, extension=
 
             norm_data = im_data / 255.0
             arr = norm_data[:,:,:3] * norm_data[:, :, 3:4] + bg * (1 - norm_data[:, :, 3:4])
-            image = Image.fromarray(np.array(arr*255.0, dtype=np.byte), "RGB")
+            alpha = norm_data[:, :, 3:4]
+            rgba = np.concatenate([arr, alpha], axis=2)
+            image = Image.fromarray(np.array(rgba * 255.0, dtype=np.uint8), "RGBA")
 
             fovy = focal2fov(fov2focal(fovx, image.size[0]), image.size[1])
             FovY = fovy 


### PR DESCRIPTION
Hi, I found a small issue in dataset_readers.py that is causing the viewpoint_cam.gt_alpha_mask to not be fetched correctly when reading a 4-channel RGBA image in a nerf_synthetic dataset. Specifically, the original dataset_readers.py reads the image using PIL, and after processing the background repackages it as an RGB image (discarding the Alpha channel) passing it into camera_utils.py to continue processing. 

All that is needed is to change the RGB file to an RGBA file.

Good luck and have a nice day!